### PR TITLE
Update to support no_std environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cty = "0.2.2"
 
 [build-dependencies]
 cc = "1.0"
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,16 @@
-use std::mem::MaybeUninit;
-use std::ops::{Add, AddAssign};
-use std::ops::{Div, DivAssign};
-use std::ops::{Mul, MulAssign};
-use std::ops::{Sub, SubAssign};
-use std::os::raw::c_int;
+#![no_std]
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::mem::MaybeUninit;
+use core::ops::{Add, AddAssign};
+use core::ops::{Div, DivAssign};
+use core::ops::{Mul, MulAssign};
+use core::ops::{Sub, SubAssign};
+use core::primitive::str;
+use cty::c_int;
 
 #[link(name = "mcl", kind = "static")]
 #[link(name = "mclbn384_256", kind = "static")]
@@ -258,7 +265,7 @@ macro_rules! str_impl {
                 if n == 0 {
                     panic!("mclBnFr_getStr");
                 }
-                unsafe { std::str::from_utf8_unchecked(&buf[0..n]).into() }
+                unsafe { core::str::from_utf8_unchecked(&buf[0..n]).into() }
             }
         }
     };
@@ -626,7 +633,7 @@ macro_rules! get_str_impl {
         if n == 0 {
             panic!("get_str");
         }
-        unsafe { std::str::from_utf8_unchecked(&buf[0..n]).into() }
+        unsafe { core::str::from_utf8_unchecked(&buf[0..n]).into() }
     }};
 }
 


### PR DESCRIPTION
This PR is to support the [`no_std`](https://docs.rust-embedded.org/book/intro/no-std.html) environment.

mcl-rust doesn't support `no_std`, so some environments like wasm and embedded devices can't use mcl-rust. 

To support their environments, this PR updates to support no_std and solve this problem.

