### PR TITLE
Add build script

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-L", "./target/thirdparty/mcl/lib"]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: herumi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: test
+on: [push]
+
+jobs:
+  build:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: sudo apt update
+    - run: git clone --depth 1 https://github.com/herumi/mcl
+    - run: cd mcl && make -j3 lib/libmcl.a lib/libmclbn384_256.a
+    - run: env RUSTFLAGS="-L./mcl/lib" cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cty = "0.2.2"
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cty = "0.2.2"
 
 [build-dependencies]
 cc = "1.0"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,7 @@ authors = ["MITSUNARI Shigeo <herumi@nifty.com>"]
 description = "a wrapper class/function of a pairing library; https://github.com/herumi/mcl"
 license = "BSD-3-Clause OR MIT OR Apache-2.0"
 edition = "2018"
-
+build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
-[build-dependencies]
-cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,22 +1,42 @@
+use std::panic;
+use std::path::Path;
 use std::process::Command;
 use std::string::String;
 
-const SCRIPTS: &str = "
-git clone https://github.com/herumi/mcl ./target/thirdparty/mcl
-cd ./target/thirdparty/mcl
-make lib/libmcl.a lib/libmclbn384_256.a -j4 CXX=clang++
+const FOLDER: &str = "./target/thirdparty/mcl";
+
+const CLONE_SCRIPTS: &str = "
+git clone https://github.com/herumi/mcl ./target/thirdparty/mcl 
 ";
 
-fn main() {
+const BUILD_SCRIPTS: &str = "
+cd ./target/thirdparty/mcl && make lib/libmcl.a lib/libmclbn384_256.a -j4 CXX=clang++
+";
+
+fn run_command(script: &str) {
+    let error_msg = format!("failed to run: {}", script);
     let output = Command::new("bash")
-        .args(["-c", SCRIPTS])
+        .args(["-c", script])
         .output()
-        .expect("error: running build.sh");
+        .expect(&error_msg);
 
-    let stdout = String::from_utf8(output.stdout).expect("error: encode command output to utf-8");
-
-    let stderr = String::from_utf8(output.stderr).expect("error: encode command output to utf-8");
+    let stdout =
+        String::from_utf8(output.stdout.clone()).expect("error: encode command output to utf-8");
+    let stderr =
+        String::from_utf8(output.stderr.clone()).expect("error: encode command output to utf-8");
 
     println!("stdout: {}", stdout);
     println!("stderr: {}", stderr);
+
+    if !output.status.success() {
+        panic!("error: failed to running commands\n{}", stderr);
+    }
+}
+
+fn main() {
+    if !Path::new(FOLDER).exists() {
+        run_command(CLONE_SCRIPTS);
+    }
+
+    run_command(BUILD_SCRIPTS);
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+use std::string::String;
+
+const SCRIPTS: &str = "
+git clone https://github.com/herumi/mcl ./target/thirdparty/mcl
+cd ./target/thirdparty/mcl
+make lib/libmcl.a lib/libmclbn384_256.a -j4 CXX=clang++
+";
+
+fn main() {
+    let output = Command::new("bash")
+        .args(["-c", SCRIPTS])
+        .output()
+        .expect("error: running build.sh");
+
+    let stdout = String::from_utf8(output.stdout).expect("error: encode command output to utf-8");
+
+    let stderr = String::from_utf8(output.stderr).expect("error: encode command output to utf-8");
+
+    println!("stdout: {}", stdout);
+    println!("stderr: {}", stderr);
+}

--- a/build.rs
+++ b/build.rs
@@ -3,15 +3,8 @@ use std::path::Path;
 use std::process::Command;
 use std::string::String;
 
-const FOLDER: &str = "./target/thirdparty/mcl";
-
-const CLONE_SCRIPTS: &str = "
-git clone https://github.com/herumi/mcl ./target/thirdparty/mcl 
-";
-
-const BUILD_SCRIPTS: &str = "
-cd ./target/thirdparty/mcl && make lib/libmcl.a lib/libmclbn384_256.a -j4 CXX=clang++
-";
+const MCL_FOLDER: &str = "./target/thirdparty/mcl";
+const MCL_REPOSITORY: &str = "https://github.com/herumi/mcl";
 
 fn run_command(script: &str) {
     let error_msg = format!("failed to run: {}", script);
@@ -34,9 +27,15 @@ fn run_command(script: &str) {
 }
 
 fn main() {
-    if !Path::new(FOLDER).exists() {
-        run_command(CLONE_SCRIPTS);
+    let clone_scripts = format!("git clone {} {}", MCL_REPOSITORY, MCL_FOLDER);
+    let build_scripts = format!(
+        "cd {} && make lib/libmcl.a lib/libmclbn384_256.a -j4 CXX=clang++",
+        MCL_FOLDER
+    );
+
+    if !Path::new(MCL_FOLDER).exists() {
+        run_command(&clone_scripts);
     }
 
-    run_command(BUILD_SCRIPTS);
+    run_command(&build_scripts);
 }

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,12 @@
 This is a wrapper library of [mcl](https://github.com/herumi/mcl/),
 which is a portable and fast pairing-based cryptography library.
 
-# Test
+dependencies
+- clang compiler
+
+# Custom MCL
+
+mcl-rust can use custom mcl with setting RUSTFLAGS.
 
 ```
 git clone https://github.com/herumi/mcl

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@ which is a portable and fast pairing-based cryptography library.
 
 dependencies
 - clang compiler
+  (by default it uses the clang compiler, but you may avoid it using custom mcl and gcc.)
 
 # Custom MCL
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,16 @@
-use std::mem::MaybeUninit;
-use std::ops::{Add, AddAssign};
-use std::ops::{Div, DivAssign};
-use std::ops::{Mul, MulAssign};
-use std::ops::{Sub, SubAssign};
-use std::os::raw::c_int;
+#![no_std]
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::mem::MaybeUninit;
+use core::ops::{Add, AddAssign};
+use core::ops::{Div, DivAssign};
+use core::ops::{Mul, MulAssign};
+use core::ops::{Sub, SubAssign};
+use core::primitive::str;
+use cty::c_int;
 
 #[link(name = "mcl", kind = "static")]
 #[link(name = "mclbn384_256", kind = "static")]
@@ -258,7 +265,7 @@ macro_rules! str_impl {
                 if n == 0 {
                     panic!("mclBnFr_getStr");
                 }
-                unsafe { std::str::from_utf8_unchecked(&buf[0..n]).into() }
+                unsafe { core::str::from_utf8_unchecked(&buf[0..n]).into() }
             }
         }
     };
@@ -626,7 +633,7 @@ macro_rules! get_str_impl {
         if n == 0 {
             panic!("get_str");
         }
-        unsafe { std::str::from_utf8_unchecked(&buf[0..n]).into() }
+        unsafe { core::str::from_utf8_unchecked(&buf[0..n]).into() }
     }};
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ use core::ops::{Div, DivAssign};
 use core::ops::{Mul, MulAssign};
 use core::ops::{Sub, SubAssign};
 use core::primitive::str;
-use cty::c_int;
 
 #[link(name = "mcl", kind = "static")]
 #[link(name = "mclbn384_256", kind = "static")]
@@ -18,7 +17,7 @@ use cty::c_int;
 #[allow(non_snake_case)]
 extern "C" {
     // global functions
-    fn mclBn_init(curve: c_int, compiledTimeVar: c_int) -> c_int;
+    fn mclBn_init(curve: i32, compiledTimeVar: i32) -> i32;
     fn mclBn_getVersion() -> u32;
     fn mclBn_getFrByteSize() -> u32;
     fn mclBn_getFpByteSize() -> u32;
@@ -36,7 +35,7 @@ extern "C" {
     fn mclBnFr_isOdd(x: *const Fr) -> i32;
     fn mclBnFr_isNegative(x: *const Fr) -> i32;
 
-    fn mclBnFr_setStr(x: *mut Fr, buf: *const u8, bufSize: usize, ioMode: i32) -> c_int;
+    fn mclBnFr_setStr(x: *mut Fr, buf: *const u8, bufSize: usize, ioMode: i32) -> i32;
     fn mclBnFr_getStr(buf: *mut u8, maxBufSize: usize, x: *const Fr, ioMode: i32) -> usize;
     fn mclBnFr_serialize(buf: *mut u8, maxBufSize: usize, x: *const Fr) -> usize;
     fn mclBnFr_deserialize(x: *mut Fr, buf: *const u8, bufSize: usize) -> usize;
@@ -65,7 +64,7 @@ extern "C" {
     fn mclBnFp_isOdd(x: *const Fp) -> i32;
     fn mclBnFp_isNegative(x: *const Fp) -> i32;
 
-    fn mclBnFp_setStr(x: *mut Fp, buf: *const u8, bufSize: usize, ioMode: i32) -> c_int;
+    fn mclBnFp_setStr(x: *mut Fp, buf: *const u8, bufSize: usize, ioMode: i32) -> i32;
     fn mclBnFp_getStr(buf: *mut u8, maxBufSize: usize, x: *const Fp, ioMode: i32) -> usize;
     fn mclBnFp_serialize(buf: *mut u8, maxBufSize: usize, x: *const Fp) -> usize;
     fn mclBnFp_deserialize(x: *mut Fp, buf: *const u8, bufSize: usize) -> usize;
@@ -90,7 +89,7 @@ extern "C" {
     fn mclBnFp2_isEqual(x: *const Fp2, y: *const Fp2) -> i32;
     fn mclBnFp2_isZero(x: *const Fp2) -> i32;
 
-    fn mclBnFp2_setStr(x: *mut Fp2, buf: *const u8, bufSize: usize, ioMode: i32) -> c_int;
+    fn mclBnFp2_setStr(x: *mut Fp2, buf: *const u8, bufSize: usize, ioMode: i32) -> i32;
     fn mclBnFp2_getStr(buf: *mut u8, maxBufSize: usize, x: *const Fp2, ioMode: i32) -> usize;
     fn mclBnFp2_serialize(buf: *mut u8, maxBufSize: usize, x: *const Fp2) -> usize;
     fn mclBnFp2_deserialize(x: *mut Fp2, buf: *const u8, bufSize: usize) -> usize;
@@ -110,7 +109,7 @@ extern "C" {
     fn mclBnG1_isValid(x: *const G1) -> i32;
     fn mclBnG1_isZero(x: *const G1) -> i32;
 
-    fn mclBnG1_setStr(x: *mut G1, buf: *const u8, bufSize: usize, ioMode: i32) -> c_int;
+    fn mclBnG1_setStr(x: *mut G1, buf: *const u8, bufSize: usize, ioMode: i32) -> i32;
     fn mclBnG1_getStr(buf: *mut u8, maxBufSize: usize, x: *const G1, ioMode: i32) -> usize;
     fn mclBnG1_serialize(buf: *mut u8, maxBufSize: usize, x: *const G1) -> usize;
     fn mclBnG1_deserialize(x: *mut G1, buf: *const u8, bufSize: usize) -> usize;
@@ -122,14 +121,14 @@ extern "C" {
     fn mclBnG1_dbl(y: *mut G1, x: *const G1);
     fn mclBnG1_mul(z: *mut G1, x: *const G1, y: *const Fr);
     fn mclBnG1_normalize(y: *mut G1, x: *const G1);
-    fn mclBnG1_hashAndMapTo(x: *mut G1, buf: *const u8, bufSize: usize) -> c_int;
+    fn mclBnG1_hashAndMapTo(x: *mut G1, buf: *const u8, bufSize: usize) -> i32;
 
     // G2
     fn mclBnG2_isEqual(x: *const G2, y: *const G2) -> i32;
     fn mclBnG2_isValid(x: *const G2) -> i32;
     fn mclBnG2_isZero(x: *const G2) -> i32;
 
-    fn mclBnG2_setStr(x: *mut G2, buf: *const u8, bufSize: usize, ioMode: i32) -> c_int;
+    fn mclBnG2_setStr(x: *mut G2, buf: *const u8, bufSize: usize, ioMode: i32) -> i32;
     fn mclBnG2_getStr(buf: *mut u8, maxBufSize: usize, x: *const G2, ioMode: i32) -> usize;
     fn mclBnG2_serialize(buf: *mut u8, maxBufSize: usize, x: *const G2) -> usize;
     fn mclBnG2_deserialize(x: *mut G2, buf: *const u8, bufSize: usize) -> usize;
@@ -141,14 +140,14 @@ extern "C" {
     fn mclBnG2_dbl(y: *mut G2, x: *const G2);
     fn mclBnG2_mul(z: *mut G2, x: *const G2, y: *const Fr);
     fn mclBnG2_normalize(y: *mut G2, x: *const G2);
-    fn mclBnG2_hashAndMapTo(x: *mut G2, buf: *const u8, bufSize: usize) -> c_int;
+    fn mclBnG2_hashAndMapTo(x: *mut G2, buf: *const u8, bufSize: usize) -> i32;
 
     // GT
     fn mclBnGT_isEqual(x: *const GT, y: *const GT) -> i32;
     fn mclBnGT_isZero(x: *const GT) -> i32;
     fn mclBnGT_isOne(x: *const GT) -> i32;
 
-    fn mclBnGT_setStr(x: *mut GT, buf: *const u8, bufSize: usize, ioMode: i32) -> c_int;
+    fn mclBnGT_setStr(x: *mut GT, buf: *const u8, bufSize: usize, ioMode: i32) -> i32;
     fn mclBnGT_getStr(buf: *mut u8, maxBufSize: usize, x: *const GT, ioMode: i32) -> usize;
     fn mclBnGT_serialize(buf: *mut u8, maxBufSize: usize, x: *const GT) -> usize;
     fn mclBnGT_deserialize(x: *mut GT, buf: *const u8, bufSize: usize) -> usize;
@@ -179,8 +178,7 @@ pub enum CurveType {
 
 const MCLBN_FP_UNIT_SIZE: usize = 6;
 const MCLBN_FR_UNIT_SIZE: usize = 4;
-const MCLBN_COMPILED_TIME_VAR: c_int =
-    MCLBN_FR_UNIT_SIZE as c_int * 10 + MCLBN_FP_UNIT_SIZE as c_int;
+const MCLBN_COMPILED_TIME_VAR: i32 = MCLBN_FR_UNIT_SIZE as i32 * 10 + MCLBN_FP_UNIT_SIZE as i32;
 
 macro_rules! common_impl {
     ($t:ty, $is_equal_fn:ident, $is_zero_fn:ident) => {
@@ -599,7 +597,7 @@ pub fn get_version() -> u32 {
 }
 
 pub fn init(curve: CurveType) -> bool {
-    unsafe { mclBn_init(curve as c_int, MCLBN_COMPILED_TIME_VAR) == 0 }
+    unsafe { mclBn_init(curve as i32, MCLBN_COMPILED_TIME_VAR) == 0 }
 }
 
 pub fn get_fr_serialized_size() -> u32 {


### PR DESCRIPTION
Add auto setup for mcl library.
With this update, the following command automatically runs when `cargo build` is running.

```sh
git clone https://github.com/herumi/mcl
cd mcl
make lib/libmcl.a lib/libmclbn384_256.a -j4 CXX=clang++
export RUSTFLAGS="-L<directory of mcl/lib>"
```

Note that this command uses clang as default to avoid errors caused by compile target option. 