### PR TITLE
Add build script to set mcl automatically

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-L", "./target/thirdparty/mcl/lib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,7 @@ authors = ["MITSUNARI Shigeo <herumi@nifty.com>"]
 description = "a wrapper class/function of a pairing library; https://github.com/herumi/mcl"
 license = "BSD-3-Clause OR MIT OR Apache-2.0"
 edition = "2018"
-
+build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
-[build-dependencies]
-cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,41 @@
+use std::panic;
+use std::path::Path;
+use std::process::Command;
+use std::string::String;
+
+const MCL_FOLDER: &str = "./target/thirdparty/mcl";
+const MCL_REPOSITORY: &str = "https://github.com/herumi/mcl";
+
+fn run_command(script: &str) {
+    let error_msg = format!("failed to run: {}", script);
+    let output = Command::new("bash")
+        .args(["-c", script])
+        .output()
+        .expect(&error_msg);
+
+    let stdout =
+        String::from_utf8(output.stdout.clone()).expect("error: encode command output to utf-8");
+    let stderr =
+        String::from_utf8(output.stderr.clone()).expect("error: encode command output to utf-8");
+
+    println!("stdout: {}", stdout);
+    println!("stderr: {}", stderr);
+
+    if !output.status.success() {
+        panic!("error: failed to running commands\n{}", stderr);
+    }
+}
+
+fn main() {
+    let clone_scripts = format!("git clone {} {}", MCL_REPOSITORY, MCL_FOLDER);
+    let build_scripts = format!(
+        "cd {} && make lib/libmcl.a lib/libmclbn384_256.a -j4 CXX=clang++",
+        MCL_FOLDER
+    );
+
+    if !Path::new(MCL_FOLDER).exists() {
+        run_command(&clone_scripts);
+    }
+
+    run_command(&build_scripts);
+}

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,13 @@
 This is a wrapper library of [mcl](https://github.com/herumi/mcl/),
 which is a portable and fast pairing-based cryptography library.
 
-# Test
+dependencies
+- clang compiler
+  (by default it uses the clang compiler, but you may avoid it using custom mcl and gcc.)
+
+# Custom MCL
+
+mcl-rust can use custom mcl with setting RUSTFLAGS.
 
 ```
 git clone https://github.com/herumi/mcl


### PR DESCRIPTION
Squashed #3 

- add build script
- add environment configuration
- update to show error message
- refactor to commonize the current directory
- update readme to follow updates
- add 'how to avoid using clang'