### PR TITLE
Update build to use cmake crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ documentation = "https://docs.rs/mcl_rust"
 [dependencies]
 
 [build-dependencies]
-cc = "1.0"
+cmake = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -1,25 +1,17 @@
-use std::env;
-use std::process::Command;
+use cmake::Config;
 
 fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let top_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let opt = if cfg!(target_arch = "x86_64") {
-        ""
-    } else {
-        "-DCMAKE_CXX_COMPILER=clang++"
-    };
+    let mut config = Config::new("mcl");
 
-    let cmd = format!(
-        "cd {out} && cmake {top}/mcl -DMCL_STATIC_LIB=ON -DMCL_STANDALONE=ON {opt} && make -j",
-        out = out_dir,
-        top = top_dir,
-        opt = opt
-    );
-    Command::new("sh")
-        .args(["-c", &cmd])
-        .output()
-        .expect("fail");
-    let s = format!("cargo:rustc-link-search=native={}/lib", out_dir);
-    println!("{}", s);
+    config
+        .define("MCL_STATIC_LIB", "ON")
+        .define("MCL_STANDALONE", "ON");
+
+    if cfg!(target_arch = "x86_64") {
+        config.define("-DCMAKE_CXX_COMPILER", "clang++");
+    }
+
+    let dst = config.build();
+
+    println!("cargo:rustc-link-search=native={}/lib", dst.display());
 }


### PR DESCRIPTION
This pull request replaces custom build script with [`cmake`](https://docs.rs/cmake/latest/cmake/) crate. This makes build errors more obvious, e.g. currently if `libgmp` is missing, build will fail with error:

```
   Compiling mcl_rust v1.0.2 (/home/necolt/workspace/mcl-rust)
error: could not find native static library `mcl`, perhaps an -L flag is missing?

error: could not compile `mcl_rust` (lib) due to 1 previous error
```

With this change, error becomes more sound:

```
error: failed to run custom build command for `mcl_rust v1.0.2 (/home/necolt/workspace/mcl-rust)`

Caused by:
  process didn't exit successfully: `/home/necolt/workspace/mcl-rust/target/debug/build/mcl_rust-6a43b59e544b741d/build-script-build` (exit status: 101)
  --- stdout
  CMAKE_TOOLCHAIN_FILE_x86_64-unknown-linux-gnu = None
  CMAKE_TOOLCHAIN_FILE_x86_64_unknown_linux_gnu = None
  HOST_CMAKE_TOOLCHAIN_FILE = None
  CMAKE_TOOLCHAIN_FILE = None
  CMAKE_GENERATOR_x86_64-unknown-linux-gnu = None
  CMAKE_GENERATOR_x86_64_unknown_linux_gnu = None
  HOST_CMAKE_GENERATOR = None
  CMAKE_GENERATOR = None
  CMAKE_PREFIX_PATH_x86_64-unknown-linux-gnu = None
  CMAKE_PREFIX_PATH_x86_64_unknown_linux_gnu = None
  HOST_CMAKE_PREFIX_PATH = None
  CMAKE_PREFIX_PATH = None
  CMAKE_x86_64-unknown-linux-gnu = None
  CMAKE_x86_64_unknown_linux_gnu = None
  HOST_CMAKE = None
  CMAKE = None
  running: cd "/home/necolt/workspace/mcl-rust/target/debug/build/mcl_rust-44297104db3300bb/out/build" && CMAKE_PREFIX_PATH="" LC_ALL="C" "cmake" "/home/necolt/workspace/mcl-rust/mcl" "-DMCL_STATIC_LIB=ON" "-DMCL_STANDALONE=ON" "-D-DCMAKE_CXX_COMPILER=clang++" "-DCMAKE_INSTALL_PREFIX=/home/necolt/workspace/mcl-rust/target/debug/build/mcl_rust-44297104db3300bb/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-unknown-linux-gnu" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_ASM_COMPILER=/usr/bin/cc" "-DCMAKE_BUILD_TYPE=Debug"
  -- Configuring incomplete, errors occurred!

  --- stderr
  CMake Error at /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
    Could NOT find GMP (missing: GMP_INCLUDE_DIR GMP_LIBRARY
    GMP_GMPXX_INCLUDE_DIR GMP_GMPXX_LIBRARY)
  Call Stack (most recent call first):
    /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
    cmake/FindGMP.cmake:53 (find_package_handle_standard_args)
    CMakeLists.txt:256 (find_package)



  thread 'main' (597662) panicked at /home/necolt/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cmake-0.1.54/src/lib.rs:1119:5:

  command did not execute successfully, got: exit status: 1

  build script failed, must exit now
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Also `cc` crate was removed, as it is unused.