### PR TITLE
Link C++ runtime with link-cplusplus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,11 @@ authors = ["MITSUNARI Shigeo <herumi@nifty.com>"]
 description = "a wrapper class/function of a pairing library; https://github.com/herumi/mcl"
 license = "BSD-3-Clause OR MIT OR Apache-2.0"
 edition = "2018"
-build = "build.rs"
-documentation = "https://docs.rs/mcl_rust"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+repository = "https://github.com/herumi/mcl-rust"
+homepage = "https://github.com/herumi/mcl"
 
 [dependencies]
+link-cplusplus = "1"
 
 [build-dependencies]
 cmake = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,8 @@
-use cmake::Config;
-
 fn main() {
-    let mut config = Config::new("mcl");
-
-    config
+    let dst = cmake::Config::new("mcl")
         .define("MCL_STATIC_LIB", "ON")
-        .define("MCL_STANDALONE", "ON");
-
-    if cfg!(target_arch = "x86_64") {
-        config.define("-DCMAKE_CXX_COMPILER", "clang++");
-    }
-
-    let dst = config.build();
-
+        .define("MCL_STANDALONE", "ON")
+        .build();
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    println!("cargo:rustc-link-lib=static=mcl");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 extern crate alloc;
+extern crate link_cplusplus;
 
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -11,8 +12,6 @@ use core::ops::{Mul, MulAssign};
 use core::ops::{Sub, SubAssign};
 use core::primitive::str;
 
-#[link(name = "mcl", kind = "static")]
-#[cfg_attr(target_arch = "x86_64", link(name = "stdc++"))]
 #[allow(non_snake_case)]
 extern "C" {
     // global functions


### PR DESCRIPTION
Currently consumers of this library must link libc++/libstdc++ etc themselves, but this should be handled by this library.

Link C++ runtime through link-cplusplus and emit mcl linkage from build.rs.